### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,42 +46,22 @@ Details on how to run the demo go here.
 
 ## Repos
 
-The MLOps demo is comprised by the following git repos:
+The MLOps demo consists of a number of git repositories:
 
 ### GitOps Repos
 
-- Cluster Bootstrap: [rh-intelligent-application-practice/openshift-cluster-bootstrap-gitops](https://github.com/rh-intelligent-application-practice/openshift-cluster-bootstrap-gitops)
+- Cluster Bootstrap: [openshift-cluster-bootstrap-gitops](https://github.com/rh-intelligent-application-practice/openshift-cluster-bootstrap-gitops) - bootstraps an OpenShift cluster with several operators and other components that are utilized for Machine Learning.
 
-- Tenant GitOps: [rh-intelligent-application-practice/mlops-demo-tenant-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-tenant-gitops)
+- Tenant GitOps: [mlops-demo-tenant-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-tenant-gitops) - project structure for a team of application developers that require several namespaces for deploying and managing an application.
 
-This repo is designed to be used alongside the openshift-cluster-bootstrap-gitops repo.  Like the openshift-cluster-bootstrap-gitops repo this repo is intended to deploy cluster level configurations but instead focuses on components that are specific to the MLOps Demo that are generally in the scope of a Cluster Admin.
-
-The primary goal of this repo is to create the tenant environment.  A tenant is generally a team of application developers that require several namespaces for deploying and managing an application.
-
-This repo creates an opinionated way for deploying and managing resources for a multi-tiered deployment of application components.
-
-- Application GitOps: [rh-intelligent-application-practice/mlops-demo-application-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-application-gitops)
-
-This repo contains resources that are deployed an managed by the application team in a gitops environment.  This repo is intended to deploy resources to the namespaces created by the tenant-gitops repo utilizing the argocd instance created by that repo.
+- Application GitOps: [mlops-demo-application-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-application-gitops) - resources that are deployed and managed by the application team.
 
 ### Application Repos
 
-#### mlops-demo-iris-training-service
+- Iris Training Service: [mlops-demo-iris-training-service](https://github.com/rh-intelligent-application-practice/mlops-demo-iris-training-service) - this repo contains source code for training the Iris machine learning model.
 
-[rh-intelligent-application-practice/mlops-demo-iris-training-service](https://github.com/rh-intelligent-application-practice/mlops-demo-iris-training-service)
-
-This repo contains source code for training the Iris machine learning model.
-
-#### mlops-demo-iris-inference-service
-
-[rh-intelligent-application-practice/mlops-demo-iris-inference-service](https://github.com/rh-intelligent-application-practice/mlops-demo-iris-inference-service)
-
-This repo contains source code for deploying the Iris machine learning model using a custom Seldon wrapper.
+- Iris Inference Service: [mlops-demo-iris-inference-service](https://github.com/rh-intelligent-application-practice/mlops-demo-iris-inference-service) - this repo contains source code for deploying the Iris machine learning model using a custom Seldon wrapper.
 
 ### Other Repos
 
-#### helm-charts
-
-[rh-intelligent-application-practice/helm-charts](https://github.com/rh-intelligent-application-practice/helm-charts)
-
-The helm-charts repo is designed to create a space to build, maintain, and version custom helm charts that can be reused by multiple projects.  This repo will automatically build and publish charts using GitHub Pages.
+- Helm Charts: [rh-intelligent-application-practice/helm-charts](https://github.com/rh-intelligent-application-practice/helm-charts) - this repo is designed to create a space to build, maintain, and version custom helm charts that can be reused by multiple projects. This repo will automatically build and publish charts using GitHub Pages.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# mlops-demo-getting-started
+# MLOps Demo: Getting Started Guide
 
-This repo is intended to serve as a high level overview of the MLOps Demo resources.
+This repo provides a high level overview of steps required to provision the MLOps Demo resources using the [Red Hat Demo Platform](https://demo.redhat.com) to host an OpenShift cluster.
 
 ## Deploying The Demo
+
+The MLOps demo is provisioned in multiple steps, each step is run from a script contained in a git repo. 
+
+The reason for separate git repos is that each one contains a core unit of work which can be used as a template for customizing specific requirements for your environment at a later date if required.
 
 ### Step One: Request a Cluster from RHPDS
 
@@ -12,57 +16,25 @@ Enter required information for Activity and Purpose. Select a geo-region closest
 
 The cluster will be created usually within an hour or so, and you should receive emails with links to access the cluster along with login credentials.
 
-### Step Two: Bootstrap openshift-cluster-bootstrap-gitops
+### Step Two: Bootstrap the MLOps OpenShift Cluster GitOps Repo
 
-Begin by cloning the [openshift-cluster-bootstrap-gitops](https://github.com/rh-intelligent-application-practice/cluster-bootstrap-gitops) repo to your local machine.
+Clone and follow the instructions found in the [openshift-cluster-bootstrap-gitops](https://github.com/rh-intelligent-application-practice/cluster-bootstrap-gitops) repo.
 
-You must have `oc` and `kustomize` installed on your local machine in order to run the bootstrap script.
+This bootstrap script will create the OpenShift-Gitops namespace, and several components will be configured to sync in the openshift-gitops instance. 
 
-If this is the first time you have run this script, you may need to add a Sealed Secret master key.  If any of your gitops repos depend on Sealed Secrets you will need to place a copy of the key in `bootstrap/base/sealed-secrets-secret.yaml`.  The project does not yet deploy any Sealed Secrets so you can skip this step and a master key will be created for you.
+This may take several minutes to complete the sync/install, you can utilize the ArgoCD URL at the bottom of the script to monitor the progress of the sync.
 
-Login to the cluster from the command line with a cluster admin user.  To obtain a login string you can utilize the `Copy login command` option from the OpenShift Web Console.
+### Step Three: Bootstrap the MLOps Demo Tenant GitOps Repo
 
-Run the `bootstrap.sh` script from the command line as you see below:
+Clone and follow the instructions found in the [mlops-demo-tenant-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-tenant-gitops) repository.
 
-```sh
-./bootstrap.sh
-```
+Additional ArgoCD Application objects will be created in OpenShift GitOps to be synced. You can follow the progress of the sync using the same URL as the previous step. This sync should complete in a few seconds.
 
-When prompted to select a bootstrap folder, choose the following:
+### Step Four: Bootstrap the MLOps Demo Application GitOps Repo
 
-```sh
-1) bootstrap/overlays/rhpds-4.11/
-```
+Clone and follow the instructions found in the [mlops-demo-application-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-gitops) repository.
 
-OpenShift-Gitops will be installed to the cluster, and several components will be configured to sync in the openshift-gitops instance.  Utilize the URL at the bottom of the script to follow the progress of the sync.  Login using the cluster admin username/password via OpenShift OAuth.  This may take several minutes to complete the sync/install.
-
-### Step Three: Bootstrap mlops-demo-tenant-gitops
-
-Clone the [mlops-demo-tenant-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-tenant-gitops) repo to your local machine.
-
-Like with the openshift-cluster-bootstrap-gitops process, you will need `oc` installed and you will need to be logged into the cluster on the command line.
-
-Run the `bootstrap.sh` script from the command line as you see below:
-
-```sh
-./bootstrap.sh
-```
-
-Additional ArgoCD Application objects will be created in OpenShift GitOps to be synced.  You can follow the progress of the sync using the same URL.  This sync should complete in a few seconds.
-
-### Step Four: Bootstrap mlops-demo-application-gitops
-
-Clone the [mlops-demo-application-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-gitops) repo to your local machine.
-
-Like with the repos, you will need `oc` installed and you will need to be logged into the cluster on the command line.
-
-Run the `bootstrap.sh` script from the command line as you see below:
-
-```sh
-./bootstrap.sh
-```
-
-This script will create several ArgoCD Application objects in the tenant ArgoCD instance and not the cluster openshift-gitops instance.  Utilize the URL at the bottom of the script to follow the progress of the sync.
+This script will create several ArgoCD Application objects in the tenant ArgoCD instance and not the cluster openshift-gitops instance. Utilize the ArgoCD URL at the bottom of the script to follow the progress of the sync.
 
 Once the sync is complete the demo environment is ready to go.
 
@@ -70,23 +42,17 @@ Once the sync is complete the demo environment is ready to go.
 
 Details on how to run the demo go here.
 
+> **_NOTE:_**  Under construction, see https://app.smartsheet.com/sheets/R52PR9x25fGrjrXwMpCGGmqRRw64vCHgvwchR2p1?rowId=5098253884974980
+
 ## Repos
+
+The MLOps demo is comprised by the following git repos:
 
 ### GitOps Repos
 
-#### openshift-cluster-bootstrap-gitops
+- Cluster Bootstrap: [rh-intelligent-application-practice/openshift-cluster-bootstrap-gitops](https://github.com/rh-intelligent-application-practice/openshift-cluster-bootstrap-gitops)
 
-[rh-intelligent-application-practice/openshift-cluster-bootstrap-gitops](https://github.com/rh-intelligent-application-practice/openshift-cluster-bootstrap-gitops)
-
-This repo contains resources used to configure cluster level resources, primarily operators.  This repo is intended to be reusable for different demos and contain a core set of OpenShift features that would commonly be used for a Data Science environment.
-
-This repo bootstraps several key resources such as OpenShift-Gitops and Sealed Secrets.  Once the initial components are deployed several ArgoCD Application objects are created which are used to install and manage the install of several operators on the cluster.
-
-One important feature of this repo is that it depends on a Sealed Secret master key which cannot be checked into git.  If you already have a master key on your local machine it will automatically utilize that that key when deploying Sealed Secrets.  If a key is not present, the bootstrap script will prompt you before deploying Sealed Secrets and saving a master key to your local machine for future reuse.  If any of your gitops repos deploy a Sealed Secret object you must have the correct master key to unseal those objects, which means you may need to get the key from the user that initially sealed the secret.
-
-#### mlops-demo-tenant-gitops
-
-[rh-intelligent-application-practice/mlops-demo-tenant-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-tenant-gitops)
+- Tenant GitOps: [rh-intelligent-application-practice/mlops-demo-tenant-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-tenant-gitops)
 
 This repo is designed to be used alongside the openshift-cluster-bootstrap-gitops repo.  Like the openshift-cluster-bootstrap-gitops repo this repo is intended to deploy cluster level configurations but instead focuses on components that are specific to the MLOps Demo that are generally in the scope of a Cluster Admin.
 
@@ -94,9 +60,7 @@ The primary goal of this repo is to create the tenant environment.  A tenant is 
 
 This repo creates an opinionated way for deploying and managing resources for a multi-tiered deployment of application components.
 
-#### mlops-demo-applicationgitops
-
-[rh-intelligent-application-practice/mlops-demo-application-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-application-gitops)
+- Application GitOps: [rh-intelligent-application-practice/mlops-demo-application-gitops](https://github.com/rh-intelligent-application-practice/mlops-demo-application-gitops)
 
 This repo contains resources that are deployed an managed by the application team in a gitops environment.  This repo is intended to deploy resources to the namespaces created by the tenant-gitops repo utilizing the argocd instance created by that repo.
 


### PR DESCRIPTION
Documentation cleanup, so that duplicated instructions don't cause a little installation confusion (e.g. sealed secrets stuff) during the process of provisioning the MLOps demo.

- Moved duplicate instructions (e.g. running bootstrap.sh) into the individual repos
- Moved repo descriptions into the individual repos
- Layout cleanup